### PR TITLE
PORT-8875 Support for preview and previous branches

### DIFF
--- a/.github/workflows/github-tenant-config-validator.yaml
+++ b/.github/workflows/github-tenant-config-validator.yaml
@@ -1,13 +1,16 @@
 name: TenantConfig Validator
 on:
   workflow_call:
-  # Triggers the workflow on push or pull request events but only for the dev , stage and main branch
+  # branches are specified for 'push' and 'pull' triggers to enable local testing
+  # (modify files in this repo instead of having to modify other repo's)
+  # The workflow trigger happens regardless of the branches included in the 'push'
+  # and 'pull' request triggers.
   push:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main,previous ]
     paths:
       - 'config/**'     
   pull_request:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main,previous ]
     paths:
       - 'config/**' 
 

--- a/.github/workflows/github-tenant-config-validator.yaml
+++ b/.github/workflows/github-tenant-config-validator.yaml
@@ -1,10 +1,6 @@
 name: TenantConfig Validator
 on:
   workflow_call:
-  # branches are specified for 'push' and 'pull' triggers to enable local testing
-  # (modify files in this repo instead of having to modify other repo's)
-  # The workflow trigger happens regardless of the branches included in the 'push'
-  # and 'pull' request triggers.
   push:
     branches: [ develop,stage,preview,main,previous ]
     paths:

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -6,10 +6,6 @@ on:
       statuscheck:
         description: "Output of Api validation job"
         value: ${{ jobs.api_validator_actions.outputs.output1 }}  
-  # branches are specified for 'push' and 'pull' triggers to enable local testing
-  # (modify files in this repo instead of having to modify other repo's)
-  # The workflow trigger happens regardless of the branches included in the 'push'
-  # and 'pull' request triggers.
   push:
     branches: [ develop,stage,preview,main, previous ]
     paths:

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -6,13 +6,16 @@ on:
       statuscheck:
         description: "Output of Api validation job"
         value: ${{ jobs.api_validator_actions.outputs.output1 }}  
-  # Triggers the workflow on push or pull request events but only for the dev , stage and main branch
+  # branches are specified for 'push' and 'pull' triggers to enable local testing
+  # (modify files in this repo instead of having to modify other repo's)
+  # The workflow trigger happens regardless of the branches included in the 'push'
+  # and 'pull' request triggers.
   push:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main, previous ]
     paths:
       - 'reference/**'     
   pull_request:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main,previous ]
     paths:
       - 'reference/**' 
       

--- a/.github/workflows/github-zip-generator.yaml
+++ b/.github/workflows/github-zip-generator.yaml
@@ -1,10 +1,6 @@
 name: API Specs ZIP Generator
 on:
   workflow_call:
-  # branches are specified for the 'push' trigger to enable local testing
-  # (modify files in this repo instead of having to modify other repo's)
-  # The workflow trigger happens regardless of the branches included in the 'push'
-  # trigger.
   push:
     branches: [ develop,stage,preview,main,previous ]
     paths:

--- a/.github/workflows/github-zip-generator.yaml
+++ b/.github/workflows/github-zip-generator.yaml
@@ -1,9 +1,12 @@
 name: API Specs ZIP Generator
 on:
-  # Triggers the workflow on push or pull request events but only for the develop , stage and main branch
-  workflow_call:  
+  workflow_call:
+  # branches are specified for the 'push' trigger to enable local testing
+  # (modify files in this repo instead of having to modify other repo's)
+  # The workflow trigger happens regardless of the branches included in the 'push'
+  # trigger.
   push:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main,previous ]
     paths:
       - 'reference/**' 
 

--- a/.github/workflows/retrigger-failed-webhook.yaml
+++ b/.github/workflows/retrigger-failed-webhook.yaml
@@ -2,10 +2,6 @@ name: Webhook Failed Retry
 on:
   workflow_dispatch:
   workflow_call:
-  # branches are specified for the 'push' trigger to enable local testing
-  # (modify files in this repo instead of having to modify other repo's)
-  # The workflow trigger happens regardless of the branches included in the 'push'
-  # trigger.
   push:
     branches: [ develop,stage,preview,main,previous ]
 

--- a/.github/workflows/retrigger-failed-webhook.yaml
+++ b/.github/workflows/retrigger-failed-webhook.yaml
@@ -1,9 +1,13 @@
 name: Webhook Failed Retry
 on:
   workflow_dispatch:
-  workflow_call: 
+  workflow_call:
+  # branches are specified for the 'push' trigger to enable local testing
+  # (modify files in this repo instead of having to modify other repo's)
+  # The workflow trigger happens regardless of the branches included in the 'push'
+  # trigger.
   push:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main,previous ]
 
 jobs:
   build:

--- a/.github/workflows/validator-service.yaml
+++ b/.github/workflows/validator-service.yaml
@@ -1,11 +1,13 @@
 name: Tenant Validator
 on:
   workflow_call:
-  # Triggers the workflow on push or pull request events but only for the dev, stage and main branch
+  # branches are specified for 'push' and 'pull' triggers to enable local testing
+  # (modify files in this repo instead of having to modify other repo's)
+  # The workflow trigger happens regardless of the branches included in the 'push'
+  # and 'pull' request triggers.
   push:
-    branches: [ develop,stage,preview,main ]
+    branches: [ develop,stage,preview,main,previous ]
   pull_request:
-    #branches: [ develop,stage,preview,main ]
     types: [opened , reopened]
    
 jobs:
@@ -15,7 +17,7 @@ jobs:
   api-zip-generator:
     needs: api_validator
     uses: ./.github/workflows/github-zip-generator.yaml
-    if: ${{ !contains( needs.api_validator.outputs.statuscheck , 'SKIPPED') && ((github.ref == 'refs/heads/develop') || (github.ref == 'refs/heads/stage') || (github.ref == 'refs/heads/main')) }}
+    if: ${{ !contains( needs.api_validator.outputs.statuscheck , 'SKIPPED') }}
     secrets: inherit         
   tenant-config-validator: 
     uses: ./.github/workflows/github-tenant-config-validator.yaml

--- a/.github/workflows/validator-service.yaml
+++ b/.github/workflows/validator-service.yaml
@@ -1,13 +1,11 @@
 name: Tenant Validator
 on:
   workflow_call:
-  # branches are specified for 'push' and 'pull' triggers to enable local testing
-  # (modify files in this repo instead of having to modify other repo's)
-  # The workflow trigger happens regardless of the branches included in the 'push'
-  # and 'pull' request triggers.
+  # Triggers the workflow on push or pull request events but only for the dev, stage, main, preview, and previous branches
   push:
     branches: [ develop,stage,preview,main,previous ]
   pull_request:
+    branches: [ develop,stage,preview,main,previous ]
     types: [opened , reopened]
    
 jobs:
@@ -17,7 +15,7 @@ jobs:
   api-zip-generator:
     needs: api_validator
     uses: ./.github/workflows/github-zip-generator.yaml
-    if: ${{ !contains( needs.api_validator.outputs.statuscheck , 'SKIPPED') }}
+    if: ${{ !contains( needs.api_validator.outputs.statuscheck , 'SKIPPED') && github.event == 'push' }}
     secrets: inherit         
   tenant-config-validator: 
     uses: ./.github/workflows/github-tenant-config-validator.yaml


### PR DESCRIPTION
Two changes:

- The `remote-actions` repo supports local testing, that is, making changes within the repo in order to test the validation actions (as opposed to having to change other repos to trigger the remote-actions actions). This local testing works for the following branches: `develop`, `stage`, `preview`, `main`. Support is being added for the `previous` branch

- Currently, the Tenant Validator limits zip generation to the following branches: `develop`, `stage`, `main`. Our tenant-onboarding supports `develop`, `stage`, `preview`, `main`, `previous`. Therefore, the limiting of zip file generation for only three branches is removed as part of this PR.