### PR TITLE
Allow trailing whitespace

### DIFF
--- a/scripts/validator-yaml.js
+++ b/scripts/validator-yaml.js
@@ -140,7 +140,7 @@ const validateIndexBody = (fileName , yamlData ,yamlJSONData ,path , reqType , a
     return false;
   }
 
-  if (body.xProxyName.length > 0 && /^[^A-Za-z]|[\W]$/.test(body.xProxyName)) {
+  if (body.xProxyName.length > 0 && /^[^A-Za-z]/.test(body.xProxyName)) {
     errorMessage(YAML_VALIDATOR, `File :${fileName} API-Path:${path} Error: Empty space at start/end of 'x-proxy-name'`);
     return false;
   }


### PR DESCRIPTION
Allow `x-proxy-name` to have trailing whitespace