### PR TITLE
PORT-11523: Add gz, msi, png supported file types

### DIFF
--- a/scripts/file-access-validator.js
+++ b/scripts/file-access-validator.js
@@ -11,8 +11,11 @@ const access_levels = ["public", "private"];
 const supported_file_types = [
   "doc",
   "docx",
+  "gz",
   "md",
+  "msi",
   "pdf",
+  "png",
   "ppt",
   "pptx",
   "txt",


### PR DESCRIPTION
 Add the following extensions `gz`, `msi`, and `png` to supported file types