### PR TITLE
Update validators

### DIFF
--- a/scripts/config-validator.js
+++ b/scripts/config-validator.js
@@ -83,25 +83,34 @@ const validateDir = async (dir, fiserv_resources) => {
             }
           }
         }
+
         if (!data?.getStartedFilePath) {
           errorMsg(
             `File ${file?.name} missing Getting Started link! Please add .md file path with property name "getStartedFilePath" in ${file?.name} file`
           );
           check = false;
         } else {
-          const file = `${args?.[0]}/${
-            data?.getStartedFilePath?.charAt(0) === "/"
-              ? data?.getStartedFilePath.substring(1)
-              : data?.getStartedFilePath
-          }`;
-          if (!fs.existsSync(file)) {
+          if (data.getStartedFilePath !== "docs/get-started.md") {
+            errorMsg(
+              `${data?.getStartedFilePath} must follow exact format 'docs/get-started.md'`
+            )
+            check = false;
+          }
+          if (!fs.existsSync(`${args?.[0]}/get-started.md`)) {
             errorMsg(
               `${data?.getStartedFilePath} doesn't exist in docs directory`
             );
             check = false;
           }
         }
+
         if (data?.resourcesFilePath) {
+          if (!data?.resourcesFilePath.startsWith("/")) {
+            errorMsg(
+              `${data?.resourcesFilePath} should follow the format 'docs/...' without starting /`
+            );
+            check = false;
+          }
           const file = `${args?.[0]}/${
             data.resourcesFilePath.charAt(0) === "/"
               ? data.resourcesFilePath.substring(1)

--- a/scripts/file-access-validator.js
+++ b/scripts/file-access-validator.js
@@ -63,6 +63,12 @@ const validateFiles = (dir, arr) => {
           );
           validFileAccessDefinition = false;
         }
+        if (file.includes(" ")) {
+          errorMsg(
+            `${file} - Contains space in name`
+          );
+          validFileAccessDefinition = false;
+        }
       }
       if (obj?.access) {
         if (!access_levels.find((x) => x === obj.access)) {


### PR DESCRIPTION
- `getStartedFilePath`: Must follow exact format `docs/get-started.md`
- `resourcesFilePath`:
  - No starting `/`
- `file-access-definition`: File names cannot have a space