### PR TITLE
Allow bare URLs (no <> brackets) in markdown

### DIFF
--- a/scripts/md-linter.js
+++ b/scripts/md-linter.js
@@ -26,6 +26,7 @@ const markdownlinter = async (dir) => {
               "first-line-heading": false,
               "heading-style": false,
               "no-inline-html": false,
+              "no-bare-urls": false,
             },
           };
           markdownlint(options, function callback(err, result) {


### PR DESCRIPTION
Generally, links must be in the format of `[link text](link)` and any link inside texts that should NOT be clickable are supposed to be `Copy paste <https://google.com> to go to google`.

However, most tenants are aware of this and some prefer to just put bare links (non-clickable) without using angle brackets (<>) in code block to make them look prettier. So I'm disabling this linter option.