### PR TITLE
Add .editorconfig, .gitattributes for standard text handling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# EditorConfig to support per-solution formatting.
+# http://editorconfig.org/
+
+# This is the default for the codeline.
+root = true
+
+# Default
+[*]
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# JavaScript and JS mixes - match eslint settings/standards
+[*.{js,json,mjs,ts,vue}]
+indent_size = 2
+
+# Markdown - match markdownlint settings
+[*.{md,markdown}]
+indent_size = 2
+
+# YAML - match standard YAML like Kubernetes and GitHub Actions
+[*.{yaml,yml}]
+indent_size = 2
+
+# Python - match PEP8 settings
+[*.py]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,76 @@
+# File settings based on dotnet/runtime
+# https://github.com/dotnet/runtime/blob/main/.gitattributes
+
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+*.doc  diff=astextplain
+*.DOC  diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF  diff=astextplain
+*.rtf  diff=astextplain
+*.RTF  diff=astextplain
+
+*.jpg  binary
+*.png  binary
+*.gif  binary
+
+# Force bash scripts to always use lf line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work.
+*.in text eol=lf
+*.sh text eol=lf
+
+# Likewise, force cmd and batch scripts to always use crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+
+*.sln text eol=crlf
+
+*.asm    text
+*.c      text
+*.clj    text
+*.config text
+*.cpp    text
+*.cs     text diff=csharp
+*.csproj text
+*.css    text
+*.cxx    text
+*.dbproj text
+*.erl    text
+*.fs     text
+*.fsproj text
+*.fsx    text
+*.h      text
+*.hs     text
+*.htm    text
+*.html   text
+*.hxx    text
+*.java   text
+*.js     text
+*.json   text
+*.less   text
+*.lisp   text
+*.lss    text
+*.lua    text
+*.m      text
+*.md     text
+*.php    text
+*.props  text
+*.py     text
+*.rb     text
+*.resx   text
+*.sass   text
+*.scss   text
+*.sql    text
+*.vb     text
+*.vbproj text
+*.yaml   text
+
+# Set linguist language for .h files explicitly based on
+# https://github.com/github/linguist/issues/1626#issuecomment-401442069
+# this only affects the repo's language statistics
+*.h linguist-language=C

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -94,12 +94,12 @@ jobs:
           echo "Temp tools directory deleted ......"
           if [[ $result == *'FAILED'* ]] ;then
             echo "Validator failed and exiting the Job..."
-            exit 1 
+            exit 1
           elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏" 
+            echo "Validator Ran Successfully....🍏"
           elif [[ $result == *'SKIPPED'* ]] ;then
             echo "Validator JOB IS SKIPPED"
-            echo "JobStatus="$result >> $GITHUB_OUTPUT                    
+            echo "JobStatus="$result >> $GITHUB_OUTPUT
           fi
         # env:
         #   GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}


### PR DESCRIPTION
This adds an `.editorconfig` to ensure contributors will use the same indent settings as other files in the repository. It also adds a `.gitattributes` to ensure line endings are handled properly across platforms and during git diff operations.

One file - `.github/workflows/github-yaml-validator.yaml` - did, indeed, have CRLF embedded instead of allowing auto line endings by platform, so that was renormalized.