### PR TITLE
Refactor common workflow code into reusable actions

### DIFF
--- a/.github/workflows/github-api-access-validator.yaml
+++ b/.github/workflows/github-api-access-validator.yaml
@@ -19,52 +19,16 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "⚠️ File not found: config/api-access-definition.yaml - skipping validation"
           fi
-      - name: Cache node modules
+      - name: Run API access definition validator
+        id: api_access_validator
+        uses: Fiserv/remote-actions/actions/run-node-script@main
         if: steps.check-file.outputs.exists == 'true'
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' && steps.check-file.outputs.exists == 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running API Access Definition Validator.....
-        if: steps.check-file.outputs.exists == 'true'
+          display-name: API access definition validator
+          script-command: apiaccess ${{ github.workspace }}
+      - name: Cleanup tools directory
+        if: always() && steps.check-file.outputs.exists == 'true'
         run: |
-          pwd
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          echo "Executing API access definition check"
-          result=$(npm run apiaccess ${{ github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          pwd
-          ls -la
           rm -rf ${{ github.workspace }}/.dev-studio-tools
           echo "Temp tools directory deleted ......"
-          if [[ $result == *'FAILED'* ]] ;then
-            echo "Validator failed and exiting the Job..."
-            exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏"
-          elif [[ $result == *'SKIPPED'* ]] ;then
-            echo "Validator JOB IS SKIPPED"
-            echo "JobStatus="$result >> $GITHUB_OUTPUT
-          fi
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-api-access-validator.yaml
+++ b/.github/workflows/github-api-access-validator.yaml
@@ -29,4 +29,3 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-api-access-validator.yaml
+++ b/.github/workflows/github-api-access-validator.yaml
@@ -27,8 +27,6 @@ jobs:
           display-name: API access definition validator
           script-command: apiaccess ${{ github.workspace }}
       - name: Cleanup tools directory
-        if: always() && steps.check-file.outputs.exists == 'true'
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        if: always()
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-api-access-validator.yaml
+++ b/.github/workflows/github-api-access-validator.yaml
@@ -1,42 +1,14 @@
 name: API Access Validator
 on:
   workflow_call:
-  # push:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "config/files-access-definiton.yaml"
-  # pull_request:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "config/files-access-definiton.yaml"
 
 jobs:
-  API-Access-Action:
+  api-access-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          pwd
-          ls -la
-          cd ${{ github.workspace }}/tools
-          ls -la
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Check if API access definition file exists
         id: check-file
         run: |
@@ -47,7 +19,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "⚠️ File not found: config/api-access-definition.yaml - skipping validation"
           fi
-
       - name: Cache node modules
         if: steps.check-file.outputs.exists == 'true'
         id: cache-npm
@@ -56,23 +27,21 @@ jobs:
           cache-name: cache-node-modules
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' && steps.check-file.outputs.exists == 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running API Access Definition Validator.....
         if: steps.check-file.outputs.exists == 'true'
         run: |
           pwd
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv
@@ -87,15 +56,15 @@ jobs:
           echo "$result"
           pwd
           ls -la
-          rm -rf ${{ github.workspace }}/tools
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
           echo "Temp tools directory deleted ......"
           if [[ $result == *'FAILED'* ]] ;then
             echo "Validator failed and exiting the Job..."
             exit 1
           elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏" 
+            echo "Validator Ran Successfully....🍏"
           elif [[ $result == *'SKIPPED'* ]] ;then
             echo "Validator JOB IS SKIPPED"
-            echo "JobStatus="$result >> $GITHUB_OUTPUT                    
+            echo "JobStatus="$result >> $GITHUB_OUTPUT
           fi
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-file-access-validator.yaml
+++ b/.github/workflows/github-file-access-validator.yaml
@@ -29,4 +29,3 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-file-access-validator.yaml
+++ b/.github/workflows/github-file-access-validator.yaml
@@ -27,8 +27,6 @@ jobs:
           display-name: file access definition validator
           script-command: fileaccess ${{ github.workspace }}
       - name: Cleanup tools directory
-        if: always() && steps.check-file.outputs.exists == 'true'
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        if: always()
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-file-access-validator.yaml
+++ b/.github/workflows/github-file-access-validator.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Check if files access definition file exists
+      - name: Check for file access definition
         id: check-file
         run: |
           if [ -f "${{ github.workspace }}/config/files-access-definition.yaml" ]; then
@@ -19,52 +19,16 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "⚠️ File not found: config/files-access-definition.yaml - skipping validation"
           fi
-      - name: Cache node modules
+      - name: Run file access definition validator
+        id: file_access_validator
+        uses: Fiserv/remote-actions/actions/run-node-script@main
         if: steps.check-file.outputs.exists == 'true'
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' && steps.check-file.outputs.exists == 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running File Access Definition Validator.....
-        if: steps.check-file.outputs.exists == 'true'
+          display-name: file access definition validator
+          script-command: fileaccess ${{ github.workspace }}
+      - name: Cleanup tools directory
+        if: always() && steps.check-file.outputs.exists == 'true'
         run: |
-          pwd
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          echo "Executing file access definition check"
-          result=$(npm run fileaccess ${{ github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          pwd
-          ls -la
           rm -rf ${{ github.workspace }}/.dev-studio-tools
           echo "Temp tools directory deleted ......"
-          if [[ $result == *'FAILED'* ]] ;then
-            echo "Validator failed and exiting the Job..."
-            exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏"
-          elif [[ $result == *'SKIPPED'* ]] ;then
-            echo "Validator JOB IS SKIPPED"
-            echo "JobStatus="$result >> $GITHUB_OUTPUT
-          fi
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-file-access-validator.yaml
+++ b/.github/workflows/github-file-access-validator.yaml
@@ -1,42 +1,14 @@
 name: File Access Validator
 on:
   workflow_call:
-  # push:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "config/files-access-definiton.yaml"
-  # pull_request:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "config/files-access-definiton.yaml"
 
 jobs:
-  File-Access-Action:
+  file-access-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          pwd
-          ls -la
-          cd ${{ github.workspace }}/tools
-          ls -la
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Check if files access definition file exists
         id: check-file
         run: |
@@ -47,7 +19,6 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "⚠️ File not found: config/files-access-definition.yaml - skipping validation"
           fi
-
       - name: Cache node modules
         if: steps.check-file.outputs.exists == 'true'
         id: cache-npm
@@ -56,23 +27,21 @@ jobs:
           cache-name: cache-node-modules
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' && steps.check-file.outputs.exists == 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running File Access Definition Validator.....
         if: steps.check-file.outputs.exists == 'true'
         run: |
           pwd
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv
@@ -87,15 +56,15 @@ jobs:
           echo "$result"
           pwd
           ls -la
-          rm -rf ${{ github.workspace }}/tools
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
           echo "Temp tools directory deleted ......"
           if [[ $result == *'FAILED'* ]] ;then
             echo "Validator failed and exiting the Job..."
             exit 1
           elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏" 
+            echo "Validator Ran Successfully....🍏"
           elif [[ $result == *'SKIPPED'* ]] ;then
             echo "Validator JOB IS SKIPPED"
-            echo "JobStatus="$result >> $GITHUB_OUTPUT                    
+            echo "JobStatus="$result >> $GITHUB_OUTPUT
           fi
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-md-linter.yaml
+++ b/.github/workflows/github-md-linter.yaml
@@ -12,45 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      job_status: ${{ steps.markdown_lint.outputs.JobStatus }}
+      job_status: ${{ steps.markdown_lint.outputs.status }}
     steps:
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running Markdown Linter.....
+      - name: Run Markdown linter
         id: markdown_lint
+        uses: Fiserv/remote-actions/actions/run-node-script@main
+        with:
+          display-name: Markdown linter
+          script-command: markdownlint ${{ github.workspace }}
+      - name: Cleanup tools directory
+        if: always()
         run: |
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          result=$(npm run markdownlint ${{ github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          if [[ $result == *'FAILED'* ]] ;then
-            echo "Validator failed and exiting the Job..."
-            exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏"
-          fi
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_lint.outputs.JobStatus }}"
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
+          echo "Temp tools directory deleted ......"
+      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_lint.outputs.status }}"

--- a/.github/workflows/github-md-linter.yaml
+++ b/.github/workflows/github-md-linter.yaml
@@ -24,7 +24,5 @@ jobs:
           script-command: markdownlint ${{ github.workspace }}
       - name: Cleanup tools directory
         if: always()
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_lint.outputs.status }}"

--- a/.github/workflows/github-md-linter.yaml
+++ b/.github/workflows/github-md-linter.yaml
@@ -25,4 +25,3 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_lint.outputs.status }}"

--- a/.github/workflows/github-md-linter.yaml
+++ b/.github/workflows/github-md-linter.yaml
@@ -1,70 +1,41 @@
-name: Markdown Validator
+name: Markdown Linter
 on:
   workflow_dispatch:
   workflow_call:
     outputs:
       statuscheck:
         description: "Output of markdown validation job"
-        value: ${{ jobs.MD-Linter-Action.outputs.job_status }}
+        value: ${{ jobs.markdown-linter.outputs.job_status }}
 
 jobs:
-  MD-Linter-Action:
+  markdown-linter:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
       job_status: ${{ steps.markdown_lint.outputs.JobStatus }}
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Creating new temp sub dir called `tools`
-        run: |
-          mkdir -m 777 tools
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          pwd
-          ls -la
-          cd ${{ github.workspace }}/tools
-          pwd
-          ls -la
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned on root"
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@main
         env:
           cache-name: cache-node-modules
         with:
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running Markdown Linter.....
         id: markdown_lint
         run: |
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv

--- a/.github/workflows/github-md-validator.yaml
+++ b/.github/workflows/github-md-validator.yaml
@@ -5,64 +5,35 @@ on:
     outputs:
       statuscheck:
         description: "Output of markdown validation job"
-        value: ${{ jobs.MD-Validator-Action.outputs.job_status }}
+        value: ${{ jobs.markdown-validator.outputs.job_status }}
 
 jobs:
-  MD-Validator-Action:
+  markdown-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
       job_status: ${{ steps.markdown_validate.outputs.JobStatus }}
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Creating new temp sub dir called `tools`
-        run: |
-          mkdir -m 777 tools
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          pwd
-          ls -la
-          cd ${{ github.workspace }}/tools
-          pwd
-          ls -la
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned on root"
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@main
         env:
           cache-name: cache-node-modules
         with:
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running Markdown Validator.....
         id: markdown_validate
         run: |
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv
@@ -76,7 +47,7 @@ jobs:
           echo "$result"
           if [[ $result == *'FAILED'* ]] ;then
             echo "Validator failed and exiting the Job..."
-            exit 1 
+            exit 1
           elif [[ $result == *'PASSED'* ]] ;then
             echo "Validator Ran Successfully....🍏"
           fi

--- a/.github/workflows/github-md-validator.yaml
+++ b/.github/workflows/github-md-validator.yaml
@@ -12,43 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      job_status: ${{ steps.markdown_validate.outputs.JobStatus }}
+      job_status: ${{ steps.markdown_validate.outputs.status }}
     steps:
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running Markdown Validator.....
+      - name: Run Markdown validator
         id: markdown_validate
+        uses: Fiserv/remote-actions/actions/run-node-script@main
+        with:
+          display-name: Markdown validator
+          script-command: markdown ${{ github.workspace }}
+      - name: Cleanup tools directory
+        if: always()
         run: |
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          result=$(npm run markdown ${{ github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          if [[ $result == *'FAILED'* ]] ;then
-            echo "Validator failed and exiting the Job..."
-            exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏"
-          fi
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_validate.outputs.JobStatus }}"
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
+          echo "Temp tools directory deleted ......"
+      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_validate.outputs.status }}"

--- a/.github/workflows/github-md-validator.yaml
+++ b/.github/workflows/github-md-validator.yaml
@@ -25,4 +25,3 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_validate.outputs.status }}"

--- a/.github/workflows/github-md-validator.yaml
+++ b/.github/workflows/github-md-validator.yaml
@@ -24,7 +24,5 @@ jobs:
           script-command: markdown ${{ github.workspace }}
       - name: Cleanup tools directory
         if: always()
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.markdown_validate.outputs.status }}"

--- a/.github/workflows/github-release-notes-validator.yaml
+++ b/.github/workflows/github-release-notes-validator.yaml
@@ -9,42 +9,14 @@ jobs:
     steps:
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
+      - name: Run release notes validator
+        uses: Fiserv/remote-actions/actions/run-node-script@main
         with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running Release Notes Validator.....
+          display-name: release notes validator
+          script-command: releasenotes ${{ github.workspace }}
+      - name: Cleanup tools directory
+        if: always()
         run: |
-          pwd
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          result=$(npm run releasenotes ${{ github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          if [[ $result == *'FAILED'* ]] ;then
-          echo "Validator failed and exiting the Job..."
-          exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-          echo "Validator Ran Successfully....🍏"
-          fi
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
+          echo "Temp tools directory deleted ......"
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-release-notes-validator.yaml
+++ b/.github/workflows/github-release-notes-validator.yaml
@@ -3,37 +3,12 @@ on:
   workflow_call:
 
 jobs:
-  Release-Notes-Validator:
+  release-notes-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          ls -la
-          cd ${{ github.workspace }}/tools
-          ls -la
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned on root"
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          pwd
-          ls -la
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@main
@@ -41,22 +16,20 @@ jobs:
           cache-name: cache-node-modules
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running Release Notes Validator.....
         run: |
           pwd
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv

--- a/.github/workflows/github-release-notes-validator.yaml
+++ b/.github/workflows/github-release-notes-validator.yaml
@@ -16,7 +16,5 @@ jobs:
           script-command: releasenotes ${{ github.workspace }}
       - name: Cleanup tools directory
         if: always()
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-release-notes-validator.yaml
+++ b/.github/workflows/github-release-notes-validator.yaml
@@ -17,4 +17,3 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-tenant-config-validator.yaml
+++ b/.github/workflows/github-tenant-config-validator.yaml
@@ -1,4 +1,4 @@
-name: TenantConfig Validator
+name: Tenant Config Validator
 on:
   workflow_call:
   # push:
@@ -11,37 +11,12 @@ on:
   #     - "config/**"
 
 jobs:
-  Tenant-Config-Action:
+  tenant-config-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          ls -la
-          cd ${{ github.workspace }}/tools
-          ls -la
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned on root"
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-      - name: List files in the repository
-        run: |
-          pwd
-          ls -la
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@main
@@ -49,24 +24,22 @@ jobs:
           cache-name: cache-node-modules
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running Tenant Config Validator.....
         env:
           API_TOKEN_GITHUB: ${{ secrets.ZIP_GENERATOR_ACTION }}
         run: |
           pwd
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv

--- a/.github/workflows/github-tenant-config-validator.yaml
+++ b/.github/workflows/github-tenant-config-validator.yaml
@@ -26,7 +26,5 @@ jobs:
           script-command: configcheck ${{ github.workspace }} ${{ vars.FISERV_INTERNAL }}
       - name: Cleanup tools directory
         if: always()
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-tenant-config-validator.yaml
+++ b/.github/workflows/github-tenant-config-validator.yaml
@@ -17,44 +17,16 @@ jobs:
     steps:
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running Tenant Config Validator.....
+      - name: Run tenant config validator
+        uses: Fiserv/remote-actions/actions/run-node-script@main
         env:
           API_TOKEN_GITHUB: ${{ secrets.ZIP_GENERATOR_ACTION }}
+        with:
+          display-name: tenant config validator
+          script-command: configcheck ${{ github.workspace }} ${{ vars.FISERV_INTERNAL }}
+      - name: Cleanup tools directory
+        if: always()
         run: |
-          pwd
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          result=$(npm run configcheck ${{ github.workspace }} ${{ vars.FISERV_INTERNAL }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          if [[ $result == *'FAILED'* ]] ;then
-          echo "Validator failed and exiting the Job..."
-          exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-          echo "Validator Ran Successfully....🍏"
-          fi
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
+          echo "Temp tools directory deleted ......"
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-tenant-config-validator.yaml
+++ b/.github/workflows/github-tenant-config-validator.yaml
@@ -1,14 +1,6 @@
 name: Tenant Config Validator
 on:
   workflow_call:
-  # push:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "config/**"
-  # pull_request:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "config/**"
 
 jobs:
   tenant-config-validator:
@@ -19,12 +11,9 @@ jobs:
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Run tenant config validator
         uses: Fiserv/remote-actions/actions/run-node-script@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.ZIP_GENERATOR_ACTION }}
         with:
           display-name: tenant config validator
           script-command: configcheck ${{ github.workspace }} ${{ vars.FISERV_INTERNAL }}
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -25,4 +25,3 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.yamlvalidate.outputs.status }}"

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -22,11 +22,7 @@ jobs:
         with:
           display-name: YAML validator
           script-command: validate ${{ github.workspace }}
-        # env:
-        #   GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
       - name: Cleanup tools directory
         if: always()
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.yamlvalidate.outputs.status }}"

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -12,56 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      output1: ${{ steps.yamlvalidate.outputs.JobStatus }}
+      output1: ${{ steps.yamlvalidate.outputs.status }}
     steps:
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running YAML Validator.....
+      - name: Run YAML validator
         id: yamlvalidate
-        run: |
-          pwd
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          result=$(npm run validate ${{github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          pwd
-          ls -la
-          rm -rf ${{github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
-          if [[ $result == *'FAILED'* ]] ;then
-            echo "Validator failed and exiting the Job..."
-            exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏"
-          elif [[ $result == *'SKIPPED'* ]] ;then
-            echo "Validator JOB IS SKIPPED"
-            echo "JobStatus="$result >> $GITHUB_OUTPUT
-          fi
+        uses: Fiserv/remote-actions/actions/run-node-script@main
+        with:
+          display-name: YAML validator
+          script-command: validate ${{ github.workspace }}
         # env:
         #   GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.yamlvalidate.outputs.JobStatus }}"
+      - name: Cleanup tools directory
+        if: always()
+        run: |
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
+          echo "Temp tools directory deleted ......"
+      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.yamlvalidate.outputs.status }}"

--- a/.github/workflows/github-yaml-validator.yaml
+++ b/.github/workflows/github-yaml-validator.yaml
@@ -1,58 +1,21 @@
-name: API Specs Validator
+name: YAML Validator
 on:
   workflow_dispatch:
   workflow_call:
     outputs:
       statuscheck:
-        description: "Output of Api validation job"
-        value: ${{ jobs.api_validator_actions.outputs.output1 }}
-  # push:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "reference/**"
-  # pull_request:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "reference/**"
+        description: "Output of YAML validation job"
+        value: ${{ jobs.yaml-validator.outputs.output1 }}
 
 jobs:
-  api_validator_actions:
+  yaml-validator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      output1: ${{ steps.apivalidate.outputs.JobStatus }}
+      output1: ${{ steps.yamlvalidate.outputs.JobStatus }}
     steps:
-      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and ${GITHUB_REF##*/} and ${GITHUB_REF#refs/heads/} and your repository is ${{ github.repository }}."
-      - name: Creating new temp sub dir called `tools`
-        run: |
-          mkdir -m 777 tools
-          cd tools
-          pwd
-          ls -la
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          pwd
-          ls -la
-          cd ${{ github.workspace }}/tools
-          pwd
-          ls -la
-      - run: echo "💡 The ${{ github.repository }} repository has been cloned on root"
-      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@main
@@ -60,23 +23,21 @@ jobs:
           cache-name: cache-node-modules
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
-      - name: Running API Specs Validator.....
-        id: apivalidate
+      - name: Running YAML Validator.....
+        id: yamlvalidate
         run: |
           pwd
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv
@@ -90,7 +51,7 @@ jobs:
           echo "$result"
           pwd
           ls -la
-          rm -rf ${{github.workspace }}/tools
+          rm -rf ${{github.workspace }}/.dev-studio-tools
           echo "Temp tools directory deleted ......"
           if [[ $result == *'FAILED'* ]] ;then
             echo "Validator failed and exiting the Job..."
@@ -103,4 +64,4 @@ jobs:
           fi
         # env:
         #   GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
-      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.apivalidate.outputs.JobStatus }}"
+      - run: echo "🍏 This job's status is ${{ job.status }} and output - ${{ steps.yamlvalidate.outputs.JobStatus }}"

--- a/.github/workflows/github-zip-generator.yaml
+++ b/.github/workflows/github-zip-generator.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Cleanup tools directory
         if: always()
         uses: Fiserv/remote-actions/actions/cleanup-tools@main
-      - run: echo "🍏 This job's status is ${{ job.status }}."
       - name: Show file content
         run: |
           pwd

--- a/.github/workflows/github-zip-generator.yaml
+++ b/.github/workflows/github-zip-generator.yaml
@@ -24,9 +24,7 @@ jobs:
           script-command: download ${{ github.workspace }}
       - name: Cleanup tools directory
         if: always()
-        run: |
-          rm -rf ${{ github.workspace }}/.dev-studio-tools
-          echo "Temp tools directory deleted ......"
+        uses: Fiserv/remote-actions/actions/cleanup-tools@main
       - run: echo "🍏 This job's status is ${{ job.status }}."
       - name: Show file content
         run: |

--- a/.github/workflows/github-zip-generator.yaml
+++ b/.github/workflows/github-zip-generator.yaml
@@ -1,13 +1,9 @@
 name: API Specs ZIP Generator
 on:
   workflow_call:
-  # push:
-  #   branches: [develop, stage, preview, main, previous]
-  #   paths:
-  #     - "reference/**"
 
 jobs:
-  ZIP-Generator-Actions:
+  zip-generator:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -19,56 +15,28 @@ jobs:
           else
             echo "🎉 The job was automatically triggered by the ${{ github.event_name }} event."
           fi
-      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      - name: Creating new temp sub dir called `tools`
-        run: |
-          mkdir -m 777 tools
-          cd tools
-          pwd
-          ls -la
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-      - name: List files in the repository
-        run: |
-          cd ${{ github.workspace }}
-          pwd
-          ls -la
-          cd ${{ github.workspace }}/tools
-          pwd
-          ls -la
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@main
         env:
           cache-name: cache-node-modules
         with:
-          path: ${{ github.workspace }}/tools/scripts/node_modules
+          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-
       - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
         name: List the state of node modules
         continue-on-error: true
         run: npm list
-
       - name: Running API Specs ZIP Generator.....
         run: |
           pwd
-          cd ${{ github.workspace }}/tools/scripts
+          cd ${{ github.workspace }}/.dev-studio-tools/scripts
           ls -la
           npmv=$(npm --version)
           echo "NPM version installed : " $npmv
@@ -94,7 +62,6 @@ jobs:
           ls -la
           mkdir -p files
           mv *.zip files
-
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
@@ -106,12 +73,10 @@ jobs:
           git commit -m "Update zip files" || echo "No changes to commit"
           git push origin devstudio-update-zip-files-${{ github.ref_name }} || echo "No changes to push"
           gh pr create --base ${{ github.ref_name }} --head devstudio-update-zip-files-${{ github.ref_name }} --title "Zip Generator Action - ${{ github.ref_name }}" --body "This PR was created automatically by Github ZIP Generator Action."
-
       - name: Merge Pull Request
         env:
           GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
         run: gh pr merge "devstudio-update-zip-files-${{ github.ref_name }}" --merge --auto --delete-branch
-
       - name: Create ZIP Artifacts
         if: failure()
         uses: actions/upload-artifact@main

--- a/.github/workflows/github-zip-generator.yaml
+++ b/.github/workflows/github-zip-generator.yaml
@@ -10,50 +10,23 @@ jobs:
       - name: Check for auto-generated ZIP files
         run: |
           if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q 'assets/files/${{ github.event.repository.name }}.*\.zip' ;then
-            echo "API zip is already being pushed, skipping generation of new one"
+            echo "API zip is already being pushed, skipping generation of new one."
             exit 1
           else
-            echo "🎉 The job was automatically triggered by the ${{ github.event_name }} event."
+            echo "The job was automatically triggered by the ${{ github.event_name }} event."
           fi
       - name: Check out code and tools
         uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
-      - name: Cache node modules
-        id: cache-npm
-        uses: actions/cache@main
-        env:
-          cache-name: cache-node-modules
+      - name: Run API zip generator
+        uses: Fiserv/remote-actions/actions/run-node-script@main
         with:
-          path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-      - name: Running API Specs ZIP Generator.....
+          display-name: API zip generator
+          script-command: download ${{ github.workspace }}
+      - name: Cleanup tools directory
+        if: always()
         run: |
-          pwd
-          cd ${{ github.workspace }}/.dev-studio-tools/scripts
-          ls -la
-          npmv=$(npm --version)
-          echo "NPM version installed : " $npmv
-          nodev=$(node --version)
-          echo "Node version installed : " $nodev
-          npm ci
-          echo " Repo: ${{ github.repository }}"
-          echo " Space: ${{ github.workspace }}"
-          result=$(npm run download ${{github.workspace }})
-          echo "**********TEST RESULTS*********************"
-          echo "$result"
-          if [[ $result == *'ZIP GENERATOR FAILED'* ]] ;then
-            echo "Validator failed and exiting the Job..."
-            exit 1
-          elif [[ $result == *'PASSED'* ]] ;then
-            echo "Validator Ran Successfully....🍏"
-          fi
+          rm -rf ${{ github.workspace }}/.dev-studio-tools
+          echo "Temp tools directory deleted ......"
       - run: echo "🍏 This job's status is ${{ job.status }}."
       - name: Show file content
         run: |
@@ -62,7 +35,7 @@ jobs:
           ls -la
           mkdir -p files
           mv *.zip files
-      - name: Create Pull Request
+      - name: Create pull request
         env:
           GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
         run: |
@@ -73,11 +46,11 @@ jobs:
           git commit -m "Update zip files" || echo "No changes to commit"
           git push origin devstudio-update-zip-files-${{ github.ref_name }} || echo "No changes to push"
           gh pr create --base ${{ github.ref_name }} --head devstudio-update-zip-files-${{ github.ref_name }} --title "Zip Generator Action - ${{ github.ref_name }}" --body "This PR was created automatically by Github ZIP Generator Action."
-      - name: Merge Pull Request
+      - name: Merge pull request
         env:
           GH_TOKEN: ${{ secrets.ZIP_GENERATOR_ACTION }}
         run: gh pr merge "devstudio-update-zip-files-${{ github.ref_name }}" --merge --auto --delete-branch
-      - name: Create ZIP Artifacts
+      - name: Create ZIP artifacts
         if: failure()
         uses: actions/upload-artifact@main
         with:

--- a/.github/workflows/post-merge-actions.yaml
+++ b/.github/workflows/post-merge-actions.yaml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'devstudio-update')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
       - name: Delete branch
         run: git push origin --delete ${{ github.event.pull_request.head.ref }}
         env:

--- a/.github/workflows/retrigger-failed-webhook.yaml
+++ b/.github/workflows/retrigger-failed-webhook.yaml
@@ -1,42 +1,21 @@
 name: Webhook Failed Retry
 on:
-  # workflow_dispatch:
   workflow_call:
-  # push:
-  #   branches: [develop, stage, preview, main, previous]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Creating new temp sub dir called `tools`
-        run: |
-          mkdir -m 750 tools
-          cd tools
-
-      - name: Check out ${{ github.repository }} Repo code at ${{ github.workspace }}
-        uses: actions/checkout@main
-        with:
-          repository: ${{ github.repository }}
-          path: ${{ github.workspace }}
-
-      - name: Check out Fiserv/remote-actions Repo code at ${{ github.workspace }}/tools
-        uses: actions/checkout@main
-        with:
-          repository: Fiserv/remote-actions
-          ref: main
-          path: ${{ github.workspace }}/tools
-
+      - name: Check out code and tools
+        uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
       - name: Set up Python
         uses: actions/setup-python@main
         with:
           python-version: 3.x
-
       - name: Install dependencies
-        run: pip install -r ${{ github.workspace }}/tools/.github/workflows/requirements.txt
-
+        run: pip install -r ${{ github.workspace }}/.dev-studio-tools/.github/workflows/requirements.txt
       - name: Run Python script
         env:
           TEST_GITHUB_AUTH_TOKEN: ${{ secrets.TEST_GITHUB_AUTH_TOKEN }}
-        run: python ${{ github.workspace }}/tools/scripts/RedeliverWebhooks.py ${{ github.repository }}
+        run: python ${{ github.workspace }}/.dev-studio-tools/scripts/RedeliverWebhooks.py ${{ github.repository }}

--- a/.github/workflows/validator-service.yaml
+++ b/.github/workflows/validator-service.yaml
@@ -1,10 +1,6 @@
 name: Tenant Validator
 on:
   workflow_call:
-  # Triggers the workflow on pull request
-  # pull_request:
-  #   branches: [develop, stage, preview, main, previous]
-  #   types: [opened, reopened]
 
 jobs:
   api_validator:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
-.vscode
 **node_modules**

--- a/actions/checkout-code-and-tools/README.md
+++ b/actions/checkout-code-and-tools/README.md
@@ -1,0 +1,5 @@
+# Checkout Code and Prepare Tools Folder
+
+This action checks out the documentation repository code and also creates a `.dev-studio-tools` folder where this actions repository will be cloned. This allows the files [in the `scripts` folder](../../scripts/) to have dependencies restored and run.
+
+A future improvement to this would be to convert all of the custom scripts into [JavaScript actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action) so this parallel checkout is not required.

--- a/actions/checkout-code-and-tools/README.md
+++ b/actions/checkout-code-and-tools/README.md
@@ -1,5 +1,19 @@
 # Checkout Code and Prepare Tools Folder
 
-This action checks out the documentation repository code and also creates a `.dev-studio-tools` folder where this actions repository will be cloned. This allows the files [in the `scripts` folder](../../scripts/) to have dependencies restored and run.
+This action checks out the documentation repository code and creates a `.dev-studio-tools` directory where this actions repository is cloned.
 
-A future improvement to this would be to convert all of the custom scripts into [JavaScript actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action) so this parallel checkout is not required.
+A future improvement to this: Convert all of the custom scripts into [JavaScript actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action) so this parallel checkout is not required.
+
+## Behavior
+
+- Creates the `${{ github.workspace }}/.dev-studio-tools` directory.
+- Checks out the current repository into `${{ github.workspace }}`.
+- Checks out `Fiserv/remote-actions` into `${{ github.workspace }}/.dev-studio-tools`.
+- Makes the files [in the `scripts` folder](../../scripts/) available so dependencies can be restored and scripts can be run.
+
+## Example
+
+```yaml
+- name: Check out code and tools
+  uses: Fiserv/remote-actions/actions/checkout-code-and-tools@main
+```

--- a/actions/checkout-code-and-tools/action.yml
+++ b/actions/checkout-code-and-tools/action.yml
@@ -1,0 +1,22 @@
+name: Check Out Code and Tools
+description: This action checks out the documentation repository code and the documentation build actions repository.
+
+runs:
+  using: composite
+  steps:
+    - name: Create `.dev-studio-tools` directory
+      shell: bash
+      run: |
+        mkdir -m 777 .dev-studio-tools
+    - name: Check out ${{ github.repository }}
+      uses: actions/checkout@main
+      with:
+        repository: ${{ github.repository }}
+        ref: ${{ github.ref }}
+        path: ${{ github.workspace }}
+    - name: Check out Developer Studio actions
+      uses: actions/checkout@main
+      with:
+        repository: Fiserv/remote-actions
+        ref: main
+        path: ${{ github.workspace }}/.dev-studio-tools

--- a/actions/cleanup-tools/README.md
+++ b/actions/cleanup-tools/README.md
@@ -1,0 +1,17 @@
+# Cleanup Tools
+
+This action removes the `.dev-studio-tools` directory from the workspace if it exists.
+
+## Behavior
+
+- Removes `${{ github.workspace }}/.dev-studio-tools` when present.
+- Does nothing when the directory is missing.
+- Does not fail when there is nothing to delete.
+
+## Example
+
+```yaml
+- name: Cleanup tools directory
+  if: always()
+  uses: Fiserv/remote-actions/actions/cleanup-tools@main
+```

--- a/actions/cleanup-tools/action.yml
+++ b/actions/cleanup-tools/action.yml
@@ -1,0 +1,17 @@
+name: Cleanup Tools
+description: Remove the .dev-studio-tools directory if it exists.
+
+runs:
+  using: composite
+  steps:
+    - name: Remove tools directory
+      shell: bash
+      run: |
+        tools_dir="${{ github.workspace }}/.dev-studio-tools"
+
+        if [[ -d "$tools_dir" ]]; then
+          rm -rf "$tools_dir"
+          echo "Removed $tools_dir"
+        else
+          echo "$tools_dir does not exist. Nothing to clean up."
+        fi

--- a/actions/run-node-script/README.md
+++ b/actions/run-node-script/README.md
@@ -1,0 +1,32 @@
+# Run Node Script
+
+This action performs the common tasks of:
+
+- Ensuring the `node_modules` for the [`scripts` folder](../../scripts/) are restored and cached.
+- Executing a Node script.
+
+A future improvement to this:
+
+- Convert all of the custom scripts into [JavaScript actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action) so this restore process is not required.
+- Use exit codes to determine success/failure instead of searching the output.
+
+## Inputs
+
+- `script-command` (required): Script or script with arguments passed to `npm run`.
+- `display-name` (optional): Friendly text shown in the action step as `Running <display-name>`.
+
+## Outputs
+
+- `status`: One of `FAILED`, `PASSED`, `SKIPPED`, or `UNKNOWN`.
+- `result`: Raw output captured from the `npm run` command.
+
+## Example
+
+```yaml
+- name: Run Markdown validator
+  id: markdown_validate
+  uses: Fiserv/remote-actions/actions/run-node-script@main
+  with:
+    display-name: Markdown validator
+    script-command: markdown ${{ github.workspace }}
+```

--- a/actions/run-node-script/action.yml
+++ b/actions/run-node-script/action.yml
@@ -1,0 +1,80 @@
+name: Run Node Script
+description: This action runs a Node.js script from the `.dev-studio-tools/scripts` directory.
+
+inputs:
+  script-command:
+    description: Script or command arguments to pass to `npm run`.
+    required: true
+  display-name:
+    description: Text shown in the execution step title after Running.
+    required: false
+    default: Node script
+
+outputs:
+  result:
+    description: Raw command output from npm run.
+    value: ${{ steps.execute.outputs.result }}
+  status:
+    description: Derived status value (FAILED, PASSED, SKIPPED, UNKNOWN).
+    value: ${{ steps.execute.outputs.status }}
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Node modules
+      id: cache-npm
+      uses: actions/cache@main
+      env:
+        cache-name: dev-studio-cache-node-modules
+      with:
+        path: ${{ github.workspace }}/.dev-studio-tools/scripts/node_modules
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+      name: List the installed Node modules
+      continue-on-error: true
+      shell: bash
+      run: npm list
+
+    - name: Run ${{ inputs.display-name }}
+      id: execute
+      shell: bash
+      run: |
+        cd ${{ github.workspace }}/.dev-studio-tools/scripts
+        echo "NPM version installed: $(npm --version)"
+        echo "Node version installed: $(node --version)"
+        npm ci
+        echo "Repo: ${{ github.repository }}"
+        echo "Space: ${{ github.workspace }}"
+        result=$(npm run ${{ inputs.script-command }})
+        status="UNKNOWN"
+
+        echo "--- OUTPUT ---"
+        echo "$result"
+        echo "--------------"
+
+        if [[ $result == *'FAILED'* ]] ;then
+          status="FAILED"
+          echo "Tool failed."
+        elif [[ $result == *'PASSED'* ]] ;then
+          status="PASSED"
+          echo "Tool succeeded."
+        elif [[ $result == *'SKIPPED'* ]] ;then
+          status="SKIPPED"
+          echo "Tool skipped."
+        fi
+
+        {
+          echo "status=$status"
+          echo "result<<EOF"
+          echo "$result"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        if [[ "$status" == "FAILED" ]] ;then
+          exit 1
+        fi


### PR DESCRIPTION
This update attempts to both standardize the output/format of each task run and reduce the copy/paste code to improve the ability to understand/maintain the build.

- Moved the `.../tools` folder "parallel checkout" location for this repo to `.../.dev-studio-tools`: This ensures tenant repositories don't accidentally step on or interfere with the clone. (`tools` is a really generic name and could easily be used by a downstream repo, inadvertently breaking the build.)
- Refactored the "checkout the source and the tools" block into a reusable action.
- Refactored the "cleanup the tools folder" block into a reusable action.
- Refactored the "restore Node modules, cache, and run `npm run XXXXX`" into a reusable action.
- Removed extra "echo" style debugging (listing files repeatedly, echoing status that can be seen in the workflow already, etc.).
- Standardized workflow and action display ("Sentence case" instead of a mix-and-match of various cases).

Why is this interesting?

1. Logs easier to read: By keeping things standard and free of extra noise, it makes errors and issues easier to locate.
2. Modifications easier to make: Removing the duplicated code means additional refactoring, enhancements, and troubleshooting will be easier to implement.
3. Context easier to understand: Both humans and AI will be more able to understand how the process works and contribute with more effect.

I've made notes in the action README files that a good future improvement for this would be to convert the folder-full-of-scripts into [JavaScript actions](https://docs.github.com/en/actions/tutorials/create-actions/create-a-javascript-action) - this would avoid the need to do Node module restore/caching. Not having to do a clone of this repo alongside the source would save time and complexity.